### PR TITLE
feat: add support for unix domain sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,10 @@ err := grace.Wait(
   10*time.Second,
   grace.WithWaitForTCP("localhost:6379"), // redis
   grace.WithWaitForTCP("localhost:5432"), // postgres
+  grace.WithWaitForUnix("/tmp/something.sock"), // something on a unix socket
   grace.WithWaitForHTTP("http://localhost:9200"), // elasticsearch
   grace.WithWaitForHTTP("http://localhost:19000/ready"), // envoy sidecar
+  grace.WithWaitForUnixHTTP("/tmp/envoy.sock", "/ready"), // HTTP over unix socket
 )
 if err != nil {
 	log.Fatal(err)

--- a/example_test.go
+++ b/example_test.go
@@ -47,7 +47,7 @@ func Example_minimal_with_healthcheck() {
 		w.Write([]byte("hello there"))
 	})
 
-	dbPinger := grace.HealthCheckerFunc(func(ctx context.Context) error {
+	dbPinger := grace.HealthCheckerFunc(func(context.Context) error {
 		// ping a database, etc.
 		return nil
 	})
@@ -99,22 +99,22 @@ func Example_full() {
 		w.Write([]byte("here are the metrics"))
 	})
 
-	dbPinger := grace.HealthCheckerFunc(func(ctx context.Context) error {
+	dbPinger := grace.HealthCheckerFunc(func(context.Context) error {
 		// ping database
 		return nil
 	})
 
-	redisPinger := grace.HealthCheckerFunc(func(ctx context.Context) error {
+	redisPinger := grace.HealthCheckerFunc(func(context.Context) error {
 		// ping redis.
 		return nil
 	})
 
-	bgWorker := func(ctx context.Context) error {
+	bgWorker := func(context.Context) error {
 		// Start some background work
 		return nil
 	}
 
-	otherBackgroundWorker := func(ctx context.Context) error {
+	otherBackgroundWorker := func(context.Context) error {
 		// Start some more background work
 		return nil
 	}

--- a/grace_test.go
+++ b/grace_test.go
@@ -58,7 +58,7 @@ func TestGrace_Run(t *testing.T) {
 		ctx := context.Background()
 		grc := grace.New(
 			ctx,
-			grace.WithBackgroundJobs(func(ctx context.Context) error {
+			grace.WithBackgroundJobs(func(context.Context) error {
 				return errors.New("wombat")
 			}),
 		)
@@ -87,7 +87,7 @@ func TestGrace_Run(t *testing.T) {
 			ctx,
 			grace.WithHealthCheckServer(
 				healthAddr,
-				grace.WithCheckers(grace.HealthCheckerFunc(func(ctx context.Context) error {
+				grace.WithCheckers(grace.HealthCheckerFunc(func(context.Context) error {
 					checkerWasCalled = true
 					return nil
 				})),

--- a/health.go
+++ b/health.go
@@ -35,7 +35,7 @@ func newHealthHandler(
 ) http.Handler {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc(livenessEndpoint, func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(livenessEndpoint, func(rw http.ResponseWriter, _ *http.Request) {
 		rw.Header().Set("Content-Type", "application/json")
 		io.WriteString(rw, `{"healthy":true}`) //nolint: errcheck
 	})

--- a/health_test.go
+++ b/health_test.go
@@ -20,7 +20,7 @@ func TestCheckerFunc_CheckHealth(t *testing.T) {
 	called := false
 	wantErr := errors.New("foo")
 
-	f := func(ctx context.Context) error {
+	f := func(context.Context) error {
 		called = true
 		return wantErr
 	}


### PR DESCRIPTION
This adds in support for having grace servers listen on unix domain sockets, as well as methods for performing HTTP wait checks against a unix socket, and simple pings that a socket is ready to receive connections. This is intended to allow servers and dependencies to be available on UDS rather than solely TCP or HTTP over TCP.


By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
