### PR TITLE
feat!: loosen requirements for WaitForTCP addr formats

### DIFF
--- a/wait_internal_test.go
+++ b/wait_internal_test.go
@@ -1,0 +1,42 @@
+package grace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_cleanTCPAddr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"example.com:123", "example.com:123"},
+		{"foobar:123", "foobar:123"},
+		{"198.51.100.0:123", "198.51.100.0:123"},
+		{"http://example.com:123", "example.com:123"},
+		{"https://example.com:123", "example.com:123"},
+		{"http://example.com", "example.com:80"},
+		{"https://example.com", "example.com:443"},
+		{"http://example.com/", "example.com:80"},
+		{"http://example.com/foo", "example.com:80"},
+		{"http://example.com:123/foo", "example.com:123"},
+		{"http://user:password@example.com:123/foo", "example.com:123"},
+		{"postgres://example.com:5432/foo", "example.com:5432"},
+		// This won't work, but we aren't going to hard-code every possible URL
+		// scheme to be able to support port-less URLs natively.
+		{"postgres://example.com/foo", "postgres://example.com/foo"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			got := cleanTCPAddr(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/wait_test.go
+++ b/wait_test.go
@@ -56,15 +56,41 @@ func Test_Wait(t *testing.T) {
 	t.Run("success tcp from url", func(t *testing.T) {
 		t.Parallel()
 
-		urls := []string{
-			"https://" + newTestAddr(t) + "/foo/bar",
-			newTestAddr(t) + "/foo/bar",
-			"https://" + newTestAddr(t),
+		tests := []struct {
+			name string
+			url  string
+		}{
+			{
+				name: "https with path",
+				url:  "https://" + newTestAddr(t) + "/foo/bar",
+			},
+			{
+				name: "https without path",
+				url:  "https://" + newTestAddr(t),
+			},
+			{
+				name: "http with path",
+				url:  "http://" + newTestAddr(t) + "/foo/bar",
+			},
+			{
+				name: "http without path",
+				url:  "http://" + newTestAddr(t),
+			},
+			{
+				name: "host port",
+				url:  newTestAddr(t),
+			},
 		}
-		for _, url := range urls {
-			ctx := context.Background()
-			err := grace.Wait(ctx, 50*time.Millisecond, grace.WithWaitForTCP(url))
-			assert.NoError(t, err)
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				ctx := context.Background()
+				err := grace.Wait(ctx, 50*time.Millisecond, grace.WithWaitForTCP(tt.url))
+				assert.NoError(t, err)
+			})
 		}
 	})
 


### PR DESCRIPTION
We have found ourselves a number of times passing regular HTTP or HTTPS URLs without ports explicitly specified into that function with the expectation that they would work, only to have them break on deployment.

This changes the strategy to support any proper URL using HTTP, HTTPS, or an explicit port specified, otherwise defaulting to the address as given. It also documents that requirement more explicitly.

BREAKING CHANGE: As a side effect, some forms of address that were previously accepted (specifically, `{host}:{port}/{path}`) are no longer valid, as they are no longer valid URLs or "host:port" combinations. I don't expect this to impact any real-world use cases, because that form doesn't follow any real-world spec, and our user base is small enough that I don't expect anyone to have hit it through Hyrum's Law. So this opts to make a breaking change now than to add more logic to handle additional off-spec formats.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
