### PR TITLE
feat: improve wait retry loop

### DIFF
--- a/wait_internal_test.go
+++ b/wait_internal_test.go
@@ -1,6 +1,8 @@
 package grace
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,4 +41,21 @@ func Test_cleanTCPAddr(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func Test_httpWaiter_waitOnce_nil_context(t *testing.T) {
+	var w httpWaiter
+
+	res := w.waitOnce(nil) //nolint:staticcheck // nil context is intentional
+	assert.False(t, res.Ok)
+	assert.EqualError(t, res.FatalErr, "net/http: nil Context")
+}
+
+func Test_waitAndRetry(t *testing.T) {
+	ctx := context.Background()
+
+	err := waitAndRetry(ctx, func(context.Context) waitResult {
+		return waitResult{FatalErr: errors.New("oh no")}
+	})
+	assert.EqualError(t, err, "oh no")
 }

--- a/wait_test.go
+++ b/wait_test.go
@@ -144,9 +144,9 @@ func Test_Wait(t *testing.T) {
 		)
 		require.Error(t, err)
 
-		wantError := fmt.Sprintf("timed out connecting to %q", addr1)
+		wantError := fmt.Sprintf("connecting to %q: failed to connect within 50ms", addr1)
 		if strings.Contains(err.Error(), addr2) {
-			wantError = fmt.Sprintf("timed out connecting to %q", addr2)
+			wantError = fmt.Sprintf("connecting to %q: failed to connect within 50ms", addr2)
 		}
 		require.EqualError(t, err, wantError)
 	})
@@ -187,7 +187,7 @@ func Test_Wait(t *testing.T) {
 		case strings.Contains(err.Error(), addr3):
 			wantAddr = addr3
 		}
-		require.EqualError(t, err, fmt.Sprintf("timed out connecting to %q", wantAddr))
+		require.EqualError(t, err, fmt.Sprintf("connecting to %q: failed to connect within 50ms", wantAddr))
 	})
 
 	t.Run("success unix", func(t *testing.T) {
@@ -215,7 +215,7 @@ func Test_Wait(t *testing.T) {
 			50*time.Millisecond,
 			grace.WithWaitForUnix(socket),
 		)
-		require.EqualError(t, err, fmt.Sprintf("timed out connecting to %q", socket))
+		require.EqualError(t, err, fmt.Sprintf("connecting to %q: failed to connect within 50ms", socket))
 	})
 
 	t.Run("success unix http", func(t *testing.T) {
@@ -265,7 +265,7 @@ func Test_Wait(t *testing.T) {
 			50*time.Millisecond,
 			grace.WithWaitForUnixHTTP(socket, "/foo/bar"),
 		)
-		require.EqualError(t, err, `timed out connecting to "http://unix/foo/bar"`)
+		require.EqualError(t, err, `connecting to "http://unix/foo/bar": failed to connect within 50ms`)
 	})
 }
 


### PR DESCRIPTION
This makes two fundamental changes to HTTP and net waiters, in addition to a couple minor things like debug log improvements and error messages:

1. Context cancellation was not properly respected for HTTP get requests. Effectively, if an HTTP request took longer to respond than the timeout, grace.Wait would let the HTTP call block indefinitely. This double fixes that by ensure the HTTP call is non-blocking, but also writing the retry loop in such a way that context cancellation is respected immediately regardless of whether any operation in between is blocking.
2. Wait retries used to be immediate. This seemed spooky, so I changed the interval to once every 100ms at most. I doubt waiting up to an extra 100ms will  matter outside of test cases.


By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
